### PR TITLE
Add capability to generate certificates with dfn acme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Role Variables
 - `elan_certbot_letsencrypt_email`: The email address for Let's Encrypt account (_required_). This is used by Let's Encrypt to send certificate expiration warnings if necessary.
 - `elan_certbot_domains`: A list specifying the domains for which the certificate should be valid. Defaults to `["{{ inventory_hostname }}"]`.
 - `elan_certbot_expand_existing`: A boolean flag that you can use e.g. as extra variable when running a playbook, to force certbot to expand already existing certificates. You should not set this to `true` as default, but only when you actually need it.
+- `elan_certbot_ca`: You can specify if you want to use `letsencrypt` (the default) or use `sectigo` with eab for DFN ACME. You then also need to define `elan_certbot_eab_kid` and `elan_certbot_eab_hmac`.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,11 @@
 ---
 elan_certbot_domains: ["{{ inventory_hostname }}"]
 elan_certbot_expand_existing: false
+
+# Specify the certificate authority to use
+# Either "letsencrypt" oder "sectigo" (for dfn acme, e.g.)
+elan_certbot_ca: letsencrypt
+
+# For eab with sectigo define these variables:
+# elan_certbot_eab_kid:
+# elan_certbot_eab_hmac:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,33 +31,71 @@
     state: started
     enabled: true
 
-- name: Generate initial certificate
-  ansible.builtin.shell:
-    cmd: >
-      certbot -n
-      -a webroot
-      --webroot-path /var/lib/nginx/
-      --agree-tos
-      -m {{ elan_certbot_letsencrypt_email }}
-      certonly
-      --domains {{ elan_certbot_domains | join(",") }}
-      --cert-name elan-certbot-certificate
-    creates: /etc/letsencrypt/live/elan-certbot-certificate/fullchain.pem
+- name: Use letsencrypt
+  when: elan_certbot_ca == "letsencrypt"
+  block:
+    - name: Generate initial certificate
+      ansible.builtin.shell:
+        cmd: >
+          certbot certonly
+          --non-interactive
+          --authenticator webroot
+          --webroot-path /var/lib/nginx/
+          --agree-tos
+          --email {{ elan_certbot_letsencrypt_email }}
+          --domains {{ elan_certbot_domains | join(",") }}
+          --cert-name elan-certbot-certificate
+        creates: /etc/letsencrypt/live/elan-certbot-certificate/fullchain.pem
+      no_log: true
+    - name: Expand existing certificate  # noqa: no-changed-when
+      when: elan_certbot_expand_existing
+      notify: Reload nginx
+      ansible.builtin.shell:
+        cmd: >
+          certbot certonly
+          --non-interactive
+          --authenticator webroot
+          --webroot-path /var/lib/nginx/
+          --agree-tos
+          --email {{ elan_certbot_letsencrypt_email }}
+          --domains {{ elan_certbot_domains | join(",") }}
+          --expand
+          --cert-name elan-certbot-certificate
+      no_log: true
 
-- name: Expand existing certificate  # noqa: no-changed-when
-  when: elan_certbot_expand_existing
-  notify: Reload nginx
-  ansible.builtin.shell:
-    cmd: >
-      certbot -n
-      -a webroot
-      --webroot-path /var/lib/nginx/
-      --agree-tos
-      -m {{ elan_certbot_letsencrypt_email }}
-      certonly
-      --domains {{ elan_certbot_domains | join(",") }}
-      --expand
-      --cert-name elan-certbot-certificate
+- name: Use sectigo
+  when: elan_certbot_ca == "sectigo"
+  block:
+    - name: Generate initial certificate
+      ansible.builtin.shell:
+        cmd: >
+          certbot certonly
+          --standalone
+          --non-interactive
+          --agree-tos
+          --email {{ elan_certbot_letsencrypt_email }}
+          --server https://acme.sectigo.com/v2/OV
+          --eab-kid {{ elan_certbot_eab_kid }}
+          --eab-hmac-key {{ elan_certbot_eab_hmac }}
+          --domains {{ elan_certbot_domains | join(",") }}
+          --cert-name elan-certbot-certificate
+        creates: /etc/letsencrypt/live/elan-certbot-certificate/fullchain.pem
+    - name: Expand existing certificate  # noqa: no-changed-when
+      when: elan_certbot_expand_existing
+      notify: Reload nginx
+      ansible.builtin.shell:
+        cmd: >
+          certbot  certonly
+          --standalone
+          --non-interactive
+          --agree-tos
+          --email {{ elan_certbot_letsencrypt_email }}
+          --server https://acme.sectigo.com/v2/OV
+          --eab-kid {{ elan_certbot_eab_kid }}
+          --eab-hmac-key {{ elan_certbot_eab_hmac }}
+          --domains {{ elan_certbot_domains | join(",") }}
+          --expand
+          --cert-name elan-certbot-certificate
 
 - name: Symlink certificates
   notify: Reload nginx


### PR DESCRIPTION
This commit introduces the capability to generate certificates using sectigo with EAB credentials, like it is necessary for the DFN ACME workflow.